### PR TITLE
Fix datatype error

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,7 +61,7 @@ class pam::params {
   case $::operatingsystem {
     'Ubuntu','Debian': {
       # base
-      $package = [ 'libpam0g', 'libpam-modules', 'libpam-runtime' ]
+      $package = 'libpam-runtime'
       # ldap
       $ldap_package = 'libpam-ldap'
       $ldapd_package = 'libpam-ldapd'


### PR DESCRIPTION
Puppet 3.7 on Debian jessie complains:

Error: Failed to apply catalog: Parameter name failed on Package[pam]:
Name must be a String not Array at
/etc/puppet/modules/pam/manifests/init.pp:68

Since libpam0g and libpam-modules are dependencies of libpam-runtime
anyways, removing those and turning the array into a string as requested
by puppet fixes the problem.