### PR TITLE
Update dependency ripienaar/concat to puppetlabs/concat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,6 @@ fixtures:
     stdlib:
       repo:  git://github.com/puppetlabs/puppetlabs-stdlib.git
       ref: 2.6.0
-    concat: git://github.com/ripienaar/puppet-concat.git
+    concat: git://github.com/puppetlabs/puppet-concat.git
   symlinks:
     pam: "#{source_dir}"

--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@ This is the Puppet module for managing PAM - Pluggable Authentication Module.
 
 ## Dependencies
 
-* puppet-concat: https://github.com/ripienaar/puppet-concat
+* puppet-concat: https://github.com/puppetlabs/puppet-concat
 * puppet-stdlib: https://github.com/puppetlabs/puppetlabs-stdlib
 
 ### Usage: pam

--- a/manifests/access.pp
+++ b/manifests/access.pp
@@ -214,7 +214,7 @@ class pam::access (
             object      => 'ALL',
             object_type => 'ALL',
             permission  => 'deny',
-            priority    => 90,
+            priority    => '90',
             except_user => 'root'
           }
         }

--- a/metadata.json
+++ b/metadata.json
@@ -20,6 +20,6 @@
    ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=2.6.0" },
-    { "name": "ripienaar/concat", "version_requirement": ">= 0.2.0" }
+    { "name": "puppetlabs/concat", "version_requirement": ">= 1.0.0" }
   ]
 }


### PR DESCRIPTION
Installing this module with puppet modules after others that depend on puppetlabs/concat one get this error

```
Notice: Downloading from https://forgeapi.puppetlabs.com ...
Error: Could not install module 'jpl-pam' (latest)
  Dependency 'ripienaar-concat' (v0.2.0) would overwrite /etc/puppet/modules/concat
    Currently, 'puppetlabs-concat' (v1.2.4) is installed to that directory
    Use `puppet module install --ignore-dependencies` to install only this module
Reading package lists...
```

Since ripienaar-concat is superseded by puppetlabs-concat I propose to update the dependency. 